### PR TITLE
Handling NoneType when checking for emails

### DIFF
--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -398,7 +398,10 @@ class ImapLibrary2(object):
         typ, msgnums = self._imap.uid('search', None, *criteria)
         if typ != 'OK':
             raise Exception('imap.search error: %s, %s, criteria=%s' % (typ, msgnums, criteria))
-        return msgnums[0].split()
+        if msgnums[0] is not None:
+            return msgnums[0].split()
+        else:
+            return []
 
     @staticmethod
     def _criteria(**kwargs):


### PR DESCRIPTION
Fixes AttributeError 'NoneType' object has no attribute 'split' when there are no emails in the folder.

If you try to use the **wait for email** keyword on a folder with no emails in it, there will be NoneType exception. This makes it so that waiting for emails is impossible and you have to workaround with RF **sleep**-keyword. I fixed this issue by checking if _msgnums_ is null before trying to split it. If the value is null we return an empty list instead so that len() can be used normally.

I tested this with my own smtp server and it works with my use cases.